### PR TITLE
manual fat removed from esi links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,34 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [2.1.0] - 2021-04-22
+
+### Changed
+
+- Ability to manually add pilots to FAT link has been disabled for ESI tracked FAT
+  links. The reason for this is pretty simple. Since an ESI tracked FAT link is
+  continuously tracking the fleet via ESI, all pilot who have been in said fleet are
+  added automatically. If someone hasn't been added, said someone wasn't in the fleet.
+
+### ⚠️ Important ⚠️
+
+If you haven't updated to the v2 version yet, do so first and do not go straight to
+this version. Read the [update instructions for v2.0.0 please](#-update-instructions-for-v200-)
+please.
+
+
 ## [2.0.1] - 2021-04-22
 
 ### Fixed
 
 - `django.db.utils.IntegrityError: (1048, "Column 'log_time' cannot be null")` on
   log merge.
+
+### ⚠️ Important ⚠️
+
+If you haven't updated to the v2 version yet, do so first and do not go straight to
+this version. Read the [update instructions for v2.0.0 please](#-update-instructions-for-v200-)
+please.
 
 
 ## [2.0.0] - 2021-04-21
@@ -58,7 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Old code for flat lists. Not used anymore and will not be used ever again
 
-### ⚠️ Update Instructions ⚠️
+### ⚠️ Update Instructions for v2.0.0 ⚠️
 
 ---
 

--- a/afat/__init__.py
+++ b/afat/__init__.py
@@ -4,5 +4,5 @@ app config
 
 default_app_config: str = "afat.apps.AfatConfig"
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __title__ = "Fleet Activity Tracking"

--- a/afat/templates/afat/partials/fatlinks/details/tabs/manualfat.html
+++ b/afat/templates/afat/partials/fatlinks/details/tabs/manualfat.html
@@ -1,40 +1,42 @@
 {% load i18n %}
 
-<div id="manualfat" class="tab-pane fade in panel panel-default">
-    <div class="panel-body">
-        <h4>{% translate "Manual FAT" %}</h4>
+{% if perms.afat.manage_afat and is_clickable_link %}
+    <div id="manualfat" class="tab-pane fade in panel panel-default">
+        <div class="panel-body">
+            <h4>{% translate "Manual FAT" %}</h4>
 
-        <p>
-            {% translate "Is someone missing from the list of FATs? Use this form to add them." %}
-            <br>
-            <strong>{% translate "Note:" %}</strong> {% translate "This action is logged!" %}
-        </p>
+            <p>
+                {% translate "Is someone missing from the list of FATs? Use this form to add them." %}
+                <br>
+                <strong>{% translate "Note:" %}</strong> {% translate "This action is logged!" %}
+            </p>
 
-        <form class="form" role="form" action="" method="POST">
-            {% csrf_token %}
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-md-12">
-                        <input type="text" class="form-control" name="character" placeholder='{% translate "Character Name" %}' required>
+            <form class="form" role="form" action="" method="POST">
+                {% csrf_token %}
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <input type="text" class="form-control" name="character" placeholder='{% translate "Character Name" %}' required>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-md-6">
-                        <input type="text" class="form-control" name="system" placeholder='{% translate "System" %}'>
-                    </div>
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <input type="text" class="form-control" name="system" placeholder='{% translate "System" %}'>
+                        </div>
 
-                    <div class="col-md-6">
-                        <input type="text" class="form-control" name="shiptype" placeholder='{% translate "Ship Type" %}'>
+                        <div class="col-md-6">
+                            <input type="text" class="form-control" name="shiptype" placeholder='{% translate "Ship Type" %}'>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="form-group text-right">
-                <button class="btn btn-primary" type="submit" name="manual_fat">{% translate "Add Manual FAT" %}</button>
-            </div>
-        </form>
+                <div class="form-group text-right">
+                    <button class="btn btn-primary" type="submit" name="manual_fat">{% translate "Add Manual FAT" %}</button>
+                </div>
+            </form>
+        </div>
     </div>
-</div>
+{% endif %}

--- a/afat/templates/afat/partials/fatlinks/details/tabs_navigation.html
+++ b/afat/templates/afat/partials/fatlinks/details/tabs_navigation.html
@@ -2,5 +2,7 @@
 
 <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" class="tab" href="#fats">{% translate "FATs" %}</a></li>
-    <li>{% if perms.afat.manage_afat %}<a data-toggle="tab" class="tab" href="#manualfat">{% translate "Manual FAT" %}</a>{% endif %}</li>
+    {% if perms.afat.manage_afat and is_clickable_link %}
+        <li><a data-toggle="tab" class="tab" href="#manualfat">{% translate "Manual FAT" %}</a></li>
+    {% endif %}
 </ul>

--- a/afat/views/fatlinks.py
+++ b/afat/views/fatlinks.py
@@ -731,11 +731,16 @@ def details_fatlink(request: WSGIRequest, fatlink_hash: str = None) -> HttpRespo
         # ESI link
         link_ongoing = False
 
+    is_clickable_link = False
+    if link.is_esilink is False:
+        is_clickable_link = True
+
     context = {
         "msg_code": msg_code,
         "message": message,
         "link": link,
-        # "flatlist": flatlist,
+        "is_esi_link": link.is_esilink,
+        "is_clickable_link": is_clickable_link,
         "link_expires": link_expires,
         "link_ongoing": link_ongoing,
         "link_can_be_reopened": link_can_be_reopened,


### PR DESCRIPTION
Ability to manually add pilots to FAT link has been disabled for ESI tracked FAT links. The reason for this is pretty simple. Since an ESI tracked FAT link is continuously tracking the fleet via ESI, all pilot who have been in said fleet are added automatically. If someone hasn't been added, said someone wasn't in the fleet.