### PR TITLE
Django 4 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+### Fixed
+
+- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
+  'ugettext_lazy' from 'django.utils.translation'
+
 
 ## [2.6.0] - 2022-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+
+## [2.7.0] - 2022-02-28
+
 ### Fixed
 
 - [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name

--- a/afat/__init__.py
+++ b/afat/__init__.py
@@ -4,5 +4,5 @@ App config
 
 default_app_config: str = "afat.apps.AfatConfig"
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 __title__ = "Fleet Activity Tracking"

--- a/afat/app_settings.py
+++ b/afat/app_settings.py
@@ -7,7 +7,7 @@ import unidecode
 
 # Django
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth (External Libs)
 from app_utils.django import clean_setting

--- a/afat/forms.py
+++ b/afat/forms.py
@@ -5,7 +5,7 @@ The forms we use
 # Django
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth AFAT
 from afat.app_settings import AFAT_DEFAULT_FATLINK_EXPIRY_TIME

--- a/testauth/urls.py
+++ b/testauth/urls.py
@@ -1,10 +1,10 @@
 # Django
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 # Alliance Auth
 from allianceauth import urls
 
 urlpatterns = [
     # Alliance Auth URLs
-    url(r"", include(urls)),
+    re_path(r"", include(urls)),
 ]


### PR DESCRIPTION
## Description

### Fixed

- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
  'ugettext_lazy' from 'django.utils.translation'


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
