### PR TITLE
Manual FAT temporarily removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [In Development] - Unreleased
 
 
+## [2.9.2] - 2022-07-11
+
+### Changed
+
+- Form for "Manual FAT" temorarily deactivated since CCP just announced that the
+  `/search` ESI endpoint will be removed tomorrow (prbably during downtime) for good,
+  which was used for this feature. Alternatives which would make this feature work
+  as until now, are currently not available. Say "Thank You CCP" ...
+
+
 ## [2.9.1] - 2022-07-11
 
 ### Added

--- a/afat/__init__.py
+++ b/afat/__init__.py
@@ -2,5 +2,5 @@
 App config
 """
 
-__version__ = "2.9.1"
+__version__ = "2.9.2"
 __title__ = "Fleet Activity Tracking"

--- a/afat/templates/afat/view/fatlinks/fatlinks_details_fatlink.html
+++ b/afat/templates/afat/view/fatlinks/fatlinks_details_fatlink.html
@@ -21,11 +21,11 @@
 
     <p>&nbsp;</p>
 
-    {% include "afat/partials/fatlinks/details/tabs_navigation.html" %}
+{#    {% include "afat/partials/fatlinks/details/tabs_navigation.html" %}#}
 
     <div class="tab-content">
         {% include "afat/partials/fatlinks/details/tabs/fats.html" %}
-        {% include "afat/partials/fatlinks/details/tabs/manualfat.html" %}
+{#        {% include "afat/partials/fatlinks/details/tabs/manualfat.html" %}#}
     </div>
 
     {% translate "Delete FAT" as translated_title %}

--- a/afat/views/fatlinks.py
+++ b/afat/views/fatlinks.py
@@ -35,12 +35,7 @@ from afat.app_settings import (
     AFAT_DEFAULT_FATLINK_REOPEN_DURATION,
     AFAT_DEFAULT_FATLINK_REOPEN_GRACE_TIME,
 )
-from afat.forms import (
-    AFatClickFatForm,
-    AFatEsiFatForm,
-    AFatManualFatForm,
-    FatLinkEditForm,
-)
+from afat.forms import AFatClickFatForm, AFatEsiFatForm, FatLinkEditForm
 from afat.helper.fatlinks import get_esi_fleet_information_by_user
 from afat.helper.time import get_time_delta
 from afat.helper.views_helper import convert_fatlinks_to_dict, convert_fats_to_dict
@@ -54,7 +49,7 @@ from afat.models import (
 )
 from afat.providers import esi
 from afat.tasks import process_fats
-from afat.utils import get_or_create_character, write_log
+from afat.utils import write_log
 
 logger = LoggerAddTag(get_extension_logger(__name__), __title__)
 
@@ -657,7 +652,7 @@ def details_fatlink(request: WSGIRequest, fatlink_hash: str) -> HttpResponse:
 
     if request.method == "POST":
         fatlink_edit_form = FatLinkEditForm(request.POST)
-        manual_fat_form = AFatManualFatForm(request.POST)
+        # manual_fat_form = AFatManualFatForm(request.POST)
 
         if fatlink_edit_form.is_valid():
             link.fleet = fatlink_edit_form.cleaned_data["fleet"]
@@ -682,52 +677,52 @@ def details_fatlink(request: WSGIRequest, fatlink_hash: str) -> HttpResponse:
                     _("<h4>Success!</h4><p>Fleet name successfully changed.</p>")
                 ),
             )
-        elif manual_fat_form.is_valid():
-            character_name = manual_fat_form.cleaned_data["character"]
-            system = manual_fat_form.cleaned_data["system"]
-            shiptype = manual_fat_form.cleaned_data["shiptype"]
-            character = get_or_create_character(name=character_name)
-
-            if character is not None:
-                AFat(
-                    afatlink_id=link.pk,
-                    character=character,
-                    system=system,
-                    shiptype=shiptype,
-                ).save()
-
-                messages.success(
-                    request,
-                    mark_safe(_("<h4>Success!</h4><p>Manual FAT processed.</p>")),
-                )
-
-                # Writing DB log
-                write_log(
-                    request=request,
-                    log_event=AFatLog.Event.MANUAL_FAT,
-                    log_text=(
-                        f"Pilot {character.character_name} "
-                        f"flying a {shiptype} was manually added"
-                    ),
-                    fatlink_hash=link.hash,
-                )
-
-                logger.info(
-                    f"Pilot {character.character_name} flying a {shiptype} was"
-                    f" manually added to FAT link with "
-                    f'hash "{link.hash}" by {request.user}'
-                )
-            else:
-                messages.error(
-                    request,
-                    mark_safe(
-                        _(
-                            "<h4>Oh No!</h4>"
-                            "<p>Manual FAT processing failed! "
-                            "The character name you entered was not found.</p>"
-                        )
-                    ),
-                )
+        # elif manual_fat_form.is_valid():
+        #     character_name = manual_fat_form.cleaned_data["character"]
+        #     system = manual_fat_form.cleaned_data["system"]
+        #     shiptype = manual_fat_form.cleaned_data["shiptype"]
+        #     character = get_or_create_character(name=character_name)
+        #
+        #     if character is not None:
+        #         AFat(
+        #             afatlink_id=link.pk,
+        #             character=character,
+        #             system=system,
+        #             shiptype=shiptype,
+        #         ).save()
+        #
+        #         messages.success(
+        #             request,
+        #             mark_safe(_("<h4>Success!</h4><p>Manual FAT processed.</p>")),
+        #         )
+        #
+        #         # Writing DB log
+        #         write_log(
+        #             request=request,
+        #             log_event=AFatLog.Event.MANUAL_FAT,
+        #             log_text=(
+        #                 f"Pilot {character.character_name} "
+        #                 f"flying a {shiptype} was manually added"
+        #             ),
+        #             fatlink_hash=link.hash,
+        #         )
+        #
+        #         logger.info(
+        #             f"Pilot {character.character_name} flying a {shiptype} was"
+        #             f" manually added to FAT link with "
+        #             f'hash "{link.hash}" by {request.user}'
+        #         )
+        #     else:
+        #         messages.error(
+        #             request,
+        #             mark_safe(
+        #                 _(
+        #                     "<h4>Oh No!</h4>"
+        #                     "<p>Manual FAT processing failed! "
+        #                     "The character name you entered was not found.</p>"
+        #                 )
+        #             ),
+        #         )
         else:
             messages.error(
                 request,


### PR DESCRIPTION
## Description

### Changed

- Form for "Manual FAT" temorarily deactivated since CCP just announced that the
  `/search` ESI endpoint will be removed tomorrow (prbably during downtime) for good,
  which was used for this feature. Alternatives which would make this feature work
  as until now, are currently not available. Say "Thank You CCP" ...


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
