### PR TITLE
[FIX] Lack of authorization check when requesting recent FatLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Lack of authorization check when requesting recent FatLinks in Dashboard Ajax call.
+  This could lead to unauthorized access to FatLinks of other users. ([#337](https://github.com/ppfeufer/allianceauth-afat/issues/337))
+
 ## \[3.0.1\] - 2024-05-16
 
 ### Change


### PR DESCRIPTION
## Description

### Fixed

- Lack of authorization check when requesting recent FatLinks in Dashboard Ajax call.
  This could lead to unauthorized access to FatLinks of other users.

Fixes #337

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
