### PR TITLE
[FIX] Closing condition for fleet

### DIFF
--- a/afat/tasks.py
+++ b/afat/tasks.py
@@ -264,6 +264,10 @@ def _process_esi_fatlink(fatlink: FatLink):
                     data_source="esi",
                     fatlink_hash=fatlink.hash,
                 )
+        else:
+            _esi_fatlinks_error_handling(
+                error_key=FatLink.EsiError.NOT_IN_FLEET, fatlink=fatlink
+            )
     else:
         _close_esi_fleet(fatlink=fatlink, reason="No FAT link creator available.")
 


### PR DESCRIPTION
## Description

### Fixed

- When the FC left the fleet and is now in another fleet, the previous fleet was not detected as no longer tracked, and as such, not closed until the FC is either in no fleet at all or offline

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
