### PR TITLE
[CHANGE] Use django-sri for sri hashes

### DIFF
--- a/.make/conf.d/django.mk
+++ b/.make/conf.d/django.mk
@@ -5,9 +5,12 @@
 pot:
 	@echo "Creating or updating .pot file …"
 	@django-admin makemessages \
-		-l en \
+		--locale en \
 		--keep-pot \
-		--ignore 'build/*'
+		--ignore 'build/*' \
+		--ignore 'node_modules/*' \
+		--ignore 'testauth/*' \
+		--ignore 'runtests.py'
 	@current_app_version=$$(pip show $(appname) | grep 'Version: ' | awk '{print $$NF}'); \
 	sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$current_app_version\\\n\"" $(translation_template); \
 	sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template);
@@ -18,9 +21,12 @@ add_translation:
 	@echo "Adding a new translation"
 	@read -p "Enter the language code (e.g. 'en_GB'): " language_code; \
 	django-admin makemessages \
-		-l $$language_code \
+		--locale $$language_code \
 		--keep-pot \
-		--ignore 'build/*'; \
+		--ignore 'build/*' \
+		--ignore 'node_modules/*' \
+		--ignore 'testauth/*' \
+		--ignore 'runtests.py'; \
 	current_app_version=$$(pip show $(appname) | grep 'Version: ' | awk '{print $$NF}'); \
 	sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$current_app_version\\\n\"" $(translation_template); \
 	sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template); \
@@ -34,21 +40,24 @@ add_translation:
 translations:
 	@echo "Creating or updating translation files"
 	@django-admin makemessages \
-		-l cs_CZ \
-		-l de \
-		-l es \
-		-l fr_FR \
-		-l it_IT \
-		-l ja \
-		-l ko_KR \
-		-l nl_NL \
-		-l pl_PL \
-		-l ru \
-		-l sk \
-		-l uk \
-		-l zh_Hans \
+		--locale cs_CZ \
+		--locale de \
+		--locale es \
+		--locale fr_FR \
+		--locale it_IT \
+		--locale ja \
+		--locale ko_KR \
+		--locale nl_NL \
+		--locale pl_PL \
+		--locale ru \
+		--locale sk \
+		--locale uk \
+		--locale zh_Hans \
 		--keep-pot \
-		--ignore 'build/*'
+		--ignore 'build/*' \
+		--ignore 'node_modules/*' \
+		--ignore 'testauth/*' \
+		--ignore 'runtests.py'
 	@current_app_version=$$(pip show $(appname) | grep 'Version: ' | awk '{print $$NF}'); \
 	sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$current_app_version\\\n\"" $(translation_template); \
 	sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template); \
@@ -69,19 +78,19 @@ translations:
 compile_translations:
 	@echo "Compiling translation files"
 	@django-admin compilemessages \
-		-l cs_CZ \
-		-l de \
-		-l es \
-		-l fr_FR \
-		-l it_IT \
-		-l ja \
-		-l ko_KR \
-		-l nl_NL \
-		-l pl_PL \
-		-l ru \
-		-l sk \
-		-l uk \
-		-l zh_Hans
+		--locale cs_CZ \
+		--locale de \
+		--locale es \
+		--locale fr_FR \
+		--locale it_IT \
+		--locale ja \
+		--locale ko_KR \
+		--locale nl_NL \
+		--locale pl_PL \
+		--locale ru \
+		--locale sk \
+		--locale uk \
+		--locale zh_Hans
 
 # Migrate all database changes
 .PHONY: migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Section Order:
 
 ### Changed
 
+- Use `django-sri` for sri hashes
+- Minimum requirements
+  - Alliance Auth >= 4.6.0
 - Character FATs table moved to its own template, so we can include it when needed instead of duplicating the template code
 
 ## [3.5.5] - 2025-01-08

--- a/afat/constants.py
+++ b/afat/constants.py
@@ -2,6 +2,9 @@
 Constants used in this module
 """
 
+# Standard Library
+import os
+
 # Alliance Auth
 from esi import __version__ as esi_version
 
@@ -12,3 +15,8 @@ APP_NAME = "allianceauth-afat"
 GITHUB_URL = f"https://github.com/ppfeufer/{APP_NAME}"
 USER_AGENT = f"{APP_NAME}/{__version__} ({GITHUB_URL}) via django-esi/{esi_version}"
 INTERNAL_URL_PREFIX = "-"
+
+# aa-srp/aasrp
+AFAT_BASE_DIR = os.path.join(os.path.dirname(__file__))
+# aa-srp/aasrp/static/aasrp
+AFAT_STATIC_DIR = os.path.join(AFAT_BASE_DIR, "static", "afat")

--- a/afat/helper/static_files.py
+++ b/afat/helper/static_files.py
@@ -1,0 +1,41 @@
+"""
+Helper functions for static integrity calculations
+"""
+
+# Standard Library
+import os
+from pathlib import Path
+
+# Third Party
+from sri import Algorithm, calculate_integrity
+
+# Alliance Auth
+from allianceauth.services.hooks import get_extension_logger
+
+# Alliance Auth (External Libs)
+from app_utils.logging import LoggerAddTag
+
+# Alliance Auth AFAT
+from afat import __title__
+from afat.constants import AFAT_STATIC_DIR
+
+logger = LoggerAddTag(my_logger=get_extension_logger(__name__), prefix=__title__)
+
+
+def calculate_integrity_hash(relative_file_path: str) -> str:
+    """
+    Calculates the integrity hash for a given static file
+    :param self:
+    :type self:
+    :param relative_file_path: The file path relative to the `allianceauth-afat/afat/static/afat` folder
+    :type relative_file_path: str
+    :return: The integrity hash
+    :rtype: str
+    """
+
+    file_path = os.path.join(AFAT_STATIC_DIR, relative_file_path)
+    integrity_hash = calculate_integrity(
+        path=Path(file_path), algorithm=Algorithm.SHA512
+    )
+
+    return integrity_hash

--- a/afat/locale/django.pot
+++ b/afat/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Alliance Auth Fleet Activity Tracker (AFAT) 3.5.5\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/allianceauth-afat/issues\n"
-"POT-Creation-Date: 2025-01-16 23:28+0100\n"
+"POT-Creation-Date: 2025-02-03 15:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1195,51 +1195,51 @@ msgid ""
 "                            "
 msgstr ""
 
-#: afat/templatetags/afat.py:43
+#: afat/templatetags/afat.py:97
 msgid "January"
 msgstr ""
 
-#: afat/templatetags/afat.py:44
+#: afat/templatetags/afat.py:98
 msgid "February"
 msgstr ""
 
-#: afat/templatetags/afat.py:45
+#: afat/templatetags/afat.py:99
 msgid "March"
 msgstr ""
 
-#: afat/templatetags/afat.py:46
+#: afat/templatetags/afat.py:100
 msgid "April"
 msgstr ""
 
-#: afat/templatetags/afat.py:47
+#: afat/templatetags/afat.py:101
 msgid "May"
 msgstr ""
 
-#: afat/templatetags/afat.py:48
+#: afat/templatetags/afat.py:102
 msgid "June"
 msgstr ""
 
-#: afat/templatetags/afat.py:49
+#: afat/templatetags/afat.py:103
 msgid "July"
 msgstr ""
 
-#: afat/templatetags/afat.py:50
+#: afat/templatetags/afat.py:104
 msgid "August"
 msgstr ""
 
-#: afat/templatetags/afat.py:51
+#: afat/templatetags/afat.py:105
 msgid "September"
 msgstr ""
 
-#: afat/templatetags/afat.py:52
+#: afat/templatetags/afat.py:106
 msgid "October"
 msgstr ""
 
-#: afat/templatetags/afat.py:53
+#: afat/templatetags/afat.py:107
 msgid "November"
 msgstr ""
 
-#: afat/templatetags/afat.py:54
+#: afat/templatetags/afat.py:108
 msgid "December"
 msgstr ""
 

--- a/afat/models.py
+++ b/afat/models.py
@@ -350,7 +350,7 @@ class Log(models.Model):
 
     class Event(models.TextChoices):
         """
-        Choices for SRP Status
+        Choices for log event
         """
 
         CREATE_FATLINK = "CR_FAT_LINK", _("FAT link created")

--- a/afat/templates/afat/bundles/afat-css.html
+++ b/afat/templates/afat/bundles/afat-css.html
@@ -1,8 +1,3 @@
 {% load afat %}
 
-<link
-    rel="stylesheet"
-    href="{% afat_static 'afat/css/afat.min.css' %}"
-    integrity="sha512-vCb9vEOW9aDVRTiOZpU3OUNl2dHQl5tShh/OPrfy4lVrrIUh9bkDHFqdq82euBB2Ezz8UaYyU0BJVMvp5CBCMQ=="
-    crossorigin="anonymous"
->
+{% afat_static "css/afat.min.css" %}

--- a/afat/templates/afat/bundles/afat-dashboard-js.html
+++ b/afat/templates/afat/bundles/afat-dashboard-js.html
@@ -1,7 +1,3 @@
 {% load afat %}
 
-<script
-    src="{% afat_static 'afat/javascript/afat-dashboard.min.js' %}"
-    integrity="sha512-sa8TGY1U0a8vEgMhwswI0nx2Z2hl/gDXu6zL5u+hmXcyKW/sM1CTVmHl07Xrk308ypVzYtlckP8dVnnwIycujA=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat-dashboard.min.js" %}

--- a/afat/templates/afat/bundles/afat-datalist-js.html
+++ b/afat/templates/afat/bundles/afat-datalist-js.html
@@ -1,8 +1,3 @@
 {% load afat %}
 
-<script
-    type="module"
-    src="{% afat_static 'afat/javascript/afat-datalist.min.js' %}"
-    integrity="sha512-gUK89zbNSyoIsWQMkctC5ig5XMdc5b43ckHxLx494yB7mGEkwtPvrt6JM8ix5Ab3I4VqZsNZCn6MDkOX0ISPYQ=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat-datalist.min.js" "module" %}

--- a/afat/templates/afat/bundles/afat-fatlink-details-js.html
+++ b/afat/templates/afat/bundles/afat-fatlink-details-js.html
@@ -1,7 +1,3 @@
 {% load afat %}
 
-<script
-    src="{% afat_static 'afat/javascript/afat-fatlink-details.min.js' %}"
-    integrity="sha512-Q7n6uEfpDJ2Ulqp8xZ9Ks47YPNCs6gujJ9FeOlzxjGmV6Ql11vWWOrJeBSXHDQpzgdoqcudHL+FEmGhUMlac/Q=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat-fatlink-details.min.js" %}

--- a/afat/templates/afat/bundles/afat-fatlist-js.html
+++ b/afat/templates/afat/bundles/afat-fatlist-js.html
@@ -1,7 +1,3 @@
 {% load afat %}
 
-<script
-    src="{% afat_static 'afat/javascript/afat-fatlist.min.js' %}"
-    integrity="sha512-clTnjAN7j4NNkRd35q6QdkfA8aurMNZfRBWG73ukRMbguCXdKUNPVu1DyhGj/Pvm5O/LdX+HG7ZsNB3BUZEOZQ=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat-fatlist.min.js" %}

--- a/afat/templates/afat/bundles/afat-js.html
+++ b/afat/templates/afat/bundles/afat-js.html
@@ -1,7 +1,3 @@
 {% load afat %}
 
-<script
-    src="{% afat_static 'afat/javascript/afat.min.js' %}"
-    integrity="sha512-ogpd4OZl6w+qpRnIDZHYAiVsC/PiVofRcKw1zv2/9fhW0Yq8/LpFnC1wow0pJ7YD+ZUlN3sTjA/ZaP/5R3WR7A=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat.min.js" %}

--- a/afat/templates/afat/bundles/afat-logs-js.html
+++ b/afat/templates/afat/bundles/afat-logs-js.html
@@ -1,7 +1,3 @@
 {% load afat %}
 
-<script
-    src="{% afat_static 'afat/javascript/afat-logs.min.js' %}"
-    integrity="sha512-ub4e+aw1LepXN6a9briLnduDA8JkmFmGsdnNwuWgRu3Pfvf4p8r5gKkXko89IsO8g6FtiABIXMiXLMcXSozgNQ=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat-logs.min.js" %}

--- a/afat/templates/afat/bundles/afat-statistics-js.html
+++ b/afat/templates/afat/bundles/afat-statistics-js.html
@@ -1,7 +1,3 @@
 {% load afat %}
 
-<script
-    src="{% afat_static 'afat/javascript/afat-statistics.min.js' %}"
-    integrity="sha512-2iwu6T7EUYNkqnNWa9SVKJw5PxJ1+tetFwnnrz/aIK8G0wRpXlaHtTG3k/QKMN1d26y+k8aOMPjGT/rl8fYLVg=="
-    crossorigin="anonymous"
-></script>
+{% afat_static "javascript/afat-statistics.min.js" %}

--- a/afat/templates/afat/partials/common/spinner.html
+++ b/afat/templates/afat/partials/common/spinner.html
@@ -3,7 +3,7 @@
 
 <div class="afat-spinner d-none text-center">
     <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="{% afat_static "afat/images/ring-resize-white-36.svg" %}">
-        <img src="{% afat_static "afat/images/ring-resize-black-36.svg" %}" alt="{% translate 'Loading …' %}">
+        <source media="(prefers-color-scheme: dark)" srcset="{% afat_static "images/ring-resize-white-36.svg" %}">
+        <img src="{% afat_static "images/ring-resize-black-36.svg" %}" alt="{% translate 'Loading …' %}">
     </picture>
 </div>

--- a/afat/templatetags/afat.py
+++ b/afat/templatetags/afat.py
@@ -1,32 +1,86 @@
 """
-Versioned static URLs to break browser caches when changing the app version
+Versioned static URLs to break browser caches when changing the app version.
 """
 
+# Standard Library
+import os
+
 # Django
+from django.conf import settings
 from django.template.defaulttags import register
 from django.templatetags.static import static
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
+# Alliance Auth
+from allianceauth.services.hooks import get_extension_logger
+
+# Alliance Auth (External Libs)
+from app_utils.logging import LoggerAddTag
+
 # Alliance Auth AFAT
-from afat import __version__
+from afat import __title__, __version__
+from afat.helper.static_files import calculate_integrity_hash
+
+logger = LoggerAddTag(my_logger=get_extension_logger(__name__), prefix=__title__)
 
 
 @register.simple_tag
-def afat_static(path: str) -> str:
+def afat_static(relative_file_path: str, script_type: str = None) -> str | None:
     """
     Versioned static URL
-    example: {% afat_static 'afat/css/allianceauth-afat.min.css' %}
 
-    :param path:
-    :type path:
-    :return:
-    :rtype:
+    :param relative_file_path: The file path relative to the `allianceauth-afat/afat/static/afat` folder
+    :type relative_file_path: str
+    :param script_type: The script type
+    :type script_type: str
+    :return: Versioned static URL
+    :rtype: str
     """
 
-    static_url = static(path=path)
-    versioned_url = static_url + "?v=" + __version__
+    logger.debug(f"Getting versioned static URL for: {relative_file_path}")
 
-    return versioned_url
+    file_type = os.path.splitext(relative_file_path)[1][1:]
+
+    logger.debug(f"File extension: {file_type}")
+
+    static_file_path = os.path.join("afat", relative_file_path)
+    static_url = static(static_file_path)
+
+    # Simply return static versioned URL for non-CSS and non-JS files
+    if file_type not in ["css", "js"]:
+        # raise ValueError(f"Unsupported file type: {file_type}")
+        return static_url + "?v=" + __version__
+
+    # Integrity hash calculation only for non-debug mode
+    sri_string = (
+        f' integrity="{calculate_integrity_hash(relative_file_path)}" crossorigin="anonymous"'
+        if not settings.DEBUG
+        else ""
+    )
+
+    # Versioned URL for CSS and JS files
+    # Add version query parameter to break browser caches when changing the app version
+    # Do not add version query parameter for libs as they are already versioned through their file path
+    versioned_url = (
+        static_url
+        if relative_file_path.startswith("libs/")
+        else static_url + "?v=" + __version__
+    )
+
+    # Return the versioned URL with integrity hash for CSS
+    if file_type == "css":
+        return mark_safe(f'<link rel="stylesheet" href="{versioned_url}"{sri_string}>')
+
+    # Return the versioned URL with integrity hash for JS files
+    if file_type == "js":
+        js_type = f' type="{script_type}"' if script_type else ""
+
+        return mark_safe(
+            f'<script{js_type} src="{versioned_url}"{sri_string}></script>'
+        )
+
+    return None
 
 
 @register.filter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "allianceauth>=4.4,<5",
+    "allianceauth>=4.6,<5",
     "allianceauth-app-utils>=1.14.1",
     "unidecode>=1.3.4",
 ]


### PR DESCRIPTION
## Description

### Changed

- Use `django-sri` for sri hashes
- Minimum requirements
  - Alliance Auth >= 4.6.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
