### PR TITLE
[CHANGE] Use Bootstrap `text-bg-*` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Change
+
+- Use Bootstrap `text-bg-*` classes to make use of Bootstrap's native text-color selection
+
 ## [3.7.1] - 2025-04-09
 
 ### Added

--- a/afat/helper/views.py
+++ b/afat/helper/views.py
@@ -51,10 +51,10 @@ def convert_fatlinks_to_dict(  # pylint: disable=too-many-locals
     # Check for ESI link
     if fatlink.is_esilink:
         via_esi = "Yes"
-        esi_fleet_marker_classes = "badge bg-secondary afat-label ms-2"
+        esi_fleet_marker_classes = "badge text-bg-secondary afat-label ms-2"
 
         if fatlink.is_registered_on_esi:
-            esi_fleet_marker_classes = "badge bg-success afat-label ms-2"
+            esi_fleet_marker_classes = "badge text-bg-success afat-label ms-2"
 
         marker_text = _("ESI")
         esi_fleet_marker += (
@@ -167,10 +167,10 @@ def convert_fats_to_dict(request: WSGIRequest, fat: Fat) -> dict:
 
     if fat.fatlink.is_esilink:
         via_esi = "Yes"
-        esi_fleet_marker_classes = "badge bg-secondary afat-label ms-2"
+        esi_fleet_marker_classes = "badge text-bg-secondary afat-label ms-2"
 
         if fat.fatlink.is_registered_on_esi:
-            esi_fleet_marker_classes = "badge bg-success afat-label ms-2"
+            esi_fleet_marker_classes = "badge text-bg-success afat-label ms-2"
 
         marker_text = _("ESI")
         esi_fleet_marker += (

--- a/afat/templates/afat/partials/fatlinks/fatlink-list-legend.html
+++ b/afat/templates/afat/partials/fatlinks/fatlink-list-legend.html
@@ -2,6 +2,6 @@
 
 <p class="fatlink-list-legend my-3 py-3 border-top">
     <b>{% translate "Legend" %}:</b><br>
-    <span class="badge bg-success afat-label">{% translate "ESI" %}</span> » {% translate "Fleet is currently active and FATs are automatically being tracked via ESI" %}<br>
-    <span class="badge bg-secondary afat-label">{% translate "ESI" %}</span> » {% translate "FATs have been automatically tracked via ESI" %}
+    <span class="badge text-bg-success afat-label">{% translate "ESI" %}</span> » {% translate "Fleet is currently active and FATs are automatically being tracked via ESI" %}<br>
+    <span class="badge text-bg-secondary afat-label">{% translate "ESI" %}</span> » {% translate "FATs have been automatically tracked via ESI" %}
 </p>

--- a/afat/templates/afat/partials/statistics/character/tabs/raw_data.html
+++ b/afat/templates/afat/partials/statistics/character/tabs/raw_data.html
@@ -27,7 +27,7 @@
                             {% endif %}
 
                             {% if fat.fatlink.is_esilink %}
-                                <span class="badge bg-secondary afat-label ms-2">ESI</span>
+                                <span class="badge text-bg-secondary afat-label ms-2">ESI</span>
                             {% endif %}
                         </td>
                         <td>

--- a/afat/tests/test_helpers.py
+++ b/afat/tests/test_helpers.py
@@ -221,7 +221,7 @@ class TestHelpers(TestCase):
             d2={
                 "pk": fatlink_1.pk,
                 "fleet_name": (
-                    'April Fleet 1<span class="badge bg-success afat-label ms-2">ESI</span>'
+                    'April Fleet 1<span class="badge text-bg-success afat-label ms-2">ESI</span>'
                 ),
                 "creator_name": creator_main_character_1,
                 "fleet_type": "",
@@ -320,7 +320,7 @@ class TestHelpers(TestCase):
         # when
         result = convert_fats_to_dict(request=request, fat=fat)
 
-        esi_marker = '<span class="badge bg-success afat-label ms-2">ESI</span>'
+        esi_marker = '<span class="badge text-bg-success afat-label ms-2">ESI</span>'
         fleet_time = fat.fatlink.created
         fleet_time_timestamp = fleet_time.timestamp()
 

--- a/afat/tests/test_views_fatlinks.py
+++ b/afat/tests/test_views_fatlinks.py
@@ -295,7 +295,7 @@ class TestFatlinksView(TestCase):
         creator_main_character = get_main_character_from_user(user=fatlink.creator)
         fleet_time = fatlink.created
         fleet_time_timestamp = fleet_time.timestamp()
-        esi_marker = '<span class="badge bg-success afat-label ms-2">ESI</span>'
+        esi_marker = '<span class="badge text-bg-success afat-label ms-2">ESI</span>'
 
         close_esi_tracking_url = reverse(
             viewname="afat:fatlinks_close_esi_fatlink", args=[fatlink_hash]


### PR DESCRIPTION
## Description

### Change

- Use Bootstrap `text-bg-*` classes to make use of Bootstrap's native text-color selection

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
