### PR TITLE
[FIX] Icon for the FAT delete button in FAT link details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Icon for the FAT delete button in FAT link details view
+
 ## [3.8.1] - 2025-05-05
 
 ### Fixed

--- a/afat/helper/views.py
+++ b/afat/helper/views.py
@@ -196,7 +196,7 @@ def convert_fats_to_dict(request: WSGIRequest, fat: Fat) -> dict:
             f'data-url="{button_delete_fat}" '
             f'data-confirm-text="{button_delete_text}" '
             f'data-body-text="{modal_body_text}">'
-            '<i class="fa-solid fa-eye"></i>'
+            '<i class="fa-solid fa-trash-can fa-fw"></i>'
             "</a>"
         )
 

--- a/afat/tests/test_helpers.py
+++ b/afat/tests/test_helpers.py
@@ -352,7 +352,7 @@ class TestHelpers(TestCase):
                     f'data-url="{button_delete_fat}" '
                     f'data-confirm-text="{button_delete_text}" '
                     f'data-body-text="{modal_body_text}">'
-                    '<i class="fa-solid fa-eye"></i></a>'
+                    '<i class="fa-solid fa-trash-can fa-fw"></i></a>'
                 ),
             },
         )


### PR DESCRIPTION
## Description

### Fixed

- Icon for the FAT delete button in FAT link details view

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
