### PR TITLE
[FIX] Ship type name shown as ID in character statistics view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Fixed
+
+- Ship type name shown as ID in character statistics view
+
 ## [6.1.0] - 2026-07-07
 
 > [!IMPORTANT]

--- a/afat/locale/django.pot
+++ b/afat/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Alliance Auth Fleet Activity Tracker (AFAT) 6.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/allianceauth-afat/issues\n"
-"POT-Creation-Date: 2026-07-07 12:36+0200\n"
+"POT-Creation-Date: 2026-07-12 11:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1479,13 +1479,17 @@ msgid ""
 "character.</p>"
 msgstr ""
 
-#: afat/views/statistics.py:381
+#: afat/views/statistics.py:263
+msgid "Unknown"
+msgstr ""
+
+#: afat/views/statistics.py:371
 msgid ""
 "This character is in a different corporation and their FATs are not counted "
 "towards the statistics of the main corporation."
 msgstr ""
 
-#: afat/views/statistics.py:459
+#: afat/views/statistics.py:449
 msgid ""
 "<h4>Warning!</h4><p>You do not have permission to view statistics for that "
 "corporation.</p>"

--- a/afat/views/statistics.py
+++ b/afat/views/statistics.py
@@ -4,7 +4,7 @@ Statistics related views
 
 # Standard Library
 import calendar
-from collections import OrderedDict, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 
 # Django
 from django.contrib import messages
@@ -253,29 +253,19 @@ def character(  # pylint: disable=too-many-locals
         character__character_id=charid,
         fatlink__created__month=month,
         fatlink__created__year=year,
-    )
+    ).select_related("character", "fatlink", "ship", "solar_system")
 
     # Data for ship type pie chart
-    data_ship_type = {}
+    ship_counter = Counter()
 
+    # Build simple counts per ship name
     for fat in fats:
-        if fat.ship_id in data_ship_type:
-            continue
+        ship_counter[getattr(fat.ship, "name", gettext_lazy("Unknown"))] += 1
 
-        data_ship_type[fat.ship_id] = fats.filter(ship=fat.ship).count()
+    colors = [get_random_rgba_color() for _ in ship_counter]
 
-    colors = []
-
-    for _ in data_ship_type:
-        bg_color_str = get_random_rgba_color()
-        colors.append(bg_color_str)
-
-    data_ship_type = [
-        # Ship type can be None, so we need to convert to string here
-        list(str(key) for key in data_ship_type),
-        list(data_ship_type.values()),
-        colors,
-    ]
+    # Format: [labels, counts, colors]
+    data_ship_type = [list(ship_counter.keys()), list(ship_counter.values()), colors]
 
     # Data for by timeline Chart
     data_time = get_fats_per_hour(fats)


### PR DESCRIPTION
## Description

### Fixed

- Ship type name shown as ID in character statistics view

  ### Before

  <img width="608" height="121" alt="image" src="https://github.com/user-attachments/assets/4422a365-b12a-4a91-b138-bcd179acd827" />

  ### After

  <img width="595" height="113" alt="image" src="https://github.com/user-attachments/assets/0775f4f1-0c4e-4bf2-8abd-ba2b21c36a8f" />

## Type of Change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
