### PR TITLE
[CHANGE] Use `pk` instead of `id` when referring to the primary key

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -3,7 +3,7 @@ name: Tests
 env:
   COVERAGE_DATABASE_VERSION: mariadb:10.11
   COVERAGE_PYTHON_VERSION: 3.12
-  NODE_VERSION: 24 # [LTS] End of Life: 30 Apr 2028 (https://endoflife.date/nodejs)
+  NODE_VERSION: 26 # [LTS] End of Life: 30 Apr 2029 (https://endoflife.date/nodejs)
   REDIS_VERSION: latest
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # The name of the file(s) to upload
           files: |
-            dist/*
+            dist/*.tar.gz
+            dist/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # Set the default language versions for the hooks
 default_language_version:
   python: python3  # Force all Python hooks to use Python 3
-  node: 24.14.0  # Force all Node hooks to use this specific Node version
+  node: 26.3.0  # Force all Node hooks to use this specific Node version
 
 # https://pre-commit.ci/
 ci:
@@ -68,7 +68,7 @@ repos:
         name: Check for large files
         description: Check for large files that were added to the repository.
         args:
-          - --maxkb=1000
+          - --maxkb=2048  # 2 MB
 
       - id: detect-private-key
         name: Detect private key
@@ -120,8 +120,10 @@ repos:
         name: End of file fixer
         description: Ensure that files end with a newline.
 
-  - repo: https://github.com/eslint/eslint
-    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+#  - repo: https://github.com/eslint/eslint
+#    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 8763fc929b6232999d541a3d8eb49965a6b71afb  # frozen: v10.6.0
     hooks:
       - id: eslint
         name: ESLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Changed
+
+- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.
+
 ## [6.1.1] - 2026-07-12
 
 ### Fixed

--- a/afat/admin.py
+++ b/afat/admin.py
@@ -138,7 +138,7 @@ class AFatLinkTypeAdmin(admin.ModelAdmin):
     Config for the FAT link type model
     """
 
-    list_display = ("id", "_name", "_is_enabled")
+    list_display = ("_name", "_is_enabled")
     list_filter = ("is_enabled",)
     ordering = ("name",)
 

--- a/afat/helper/views.py
+++ b/afat/helper/views.py
@@ -334,7 +334,7 @@ def convert_fats_to_dict(request: WSGIRequest, fat: Fat) -> dict:
     actions_parts = []
     if has_manage:
         button_delete_fat = reverse(
-            "afat:fatlinks_delete_fat", args=[fat.fatlink.hash, fat.id]
+            "afat:fatlinks_delete_fat", args=[fat.fatlink.hash, fat.pk]
         )
         modal_body_text = _(
             "<p>Are you sure you want to remove {character_name} from this FAT link?</p>"

--- a/afat/migrations/0002_use_sde_for_fats.py
+++ b/afat/migrations/0002_use_sde_for_fats.py
@@ -114,7 +114,7 @@ def _on_migrate_sde_relationships(apps, schema_editor) -> None:
     # Bulk delete in chunks of DB_CHUNK_SIZE
     deleted_count = 0
     for chunk_ids in _chunks(to_delete_ids, DB_CHUNK_SIZE):
-        fat_model.objects.using(db_alias).filter(id__in=chunk_ids).delete()
+        fat_model.objects.using(db_alias).filter(pk__in=chunk_ids).delete()
         deleted_count += len(chunk_ids)
 
     print(f"Bulk update completed. Updated: {updated_count}, Deleted: {deleted_count}")

--- a/afat/models/smart_filter.py
+++ b/afat/models/smart_filter.py
@@ -191,7 +191,7 @@ class FatsInTimeFilter(BaseFilter):
 
         users = defaultdict(list)
         for f in fats:
-            users[f.character.character_ownership.user.pk].append(f.id)
+            users[f.character.character_ownership.user.pk].append(f.pk)
 
         output = defaultdict(lambda: {"message": 0, "check": False})
         for u, fat_list in users.items():

--- a/afat/tests/fixtures/generate_fat_links.py
+++ b/afat/tests/fixtures/generate_fat_links.py
@@ -80,7 +80,7 @@ for _ in range(LINKS_NUMBER):
         population=characters, k=random.randint(a=1, b=MAX_PILOTS_IN_FLEET)
     ):
         Fat.objects.create(
-            character_id=character.id,
+            character_id=character.pk,
             fatlink=fat_link,
             system="Jita",
             shiptype="Ibis",

--- a/afat/tests/test_helper.py
+++ b/afat/tests/test_helper.py
@@ -467,7 +467,7 @@ class TestHelperConvertFatsToDict(BaseTestCase):
             ship=ship,
             character=character,
             fatlink=fatlink,
-            id=42,
+            pk=42,
         )
 
         result = convert_fats_to_dict(request=request, fat=fat)

--- a/afat/tests/test_views_fatlinks.py
+++ b/afat/tests/test_views_fatlinks.py
@@ -1185,7 +1185,7 @@ class TestAjaxGetFatsByFatlink(FatlinksViewTestCase):
 
         # Create a mock Fat object with realistic attributes
         class MockFat:
-            id = 1
+            pk = 1
             shiptype = "Omen"
             system = "Jita"
 
@@ -1214,7 +1214,7 @@ class TestAjaxGetFatsByFatlink(FatlinksViewTestCase):
 
         # Mock the convert_fats_to_dict function to return a JSON-serializable dictionary
         mock_convert_fats_to_dict.return_value = {
-            "id": mock_fat.id,
+            "id": mock_fat.pk,
             "character": mock_fat.character.character_name,
             "shiptype": mock_fat.shiptype,
         }

--- a/afat/views/dashboard.py
+++ b/afat/views/dashboard.py
@@ -101,10 +101,10 @@ def ajax_get_recent_fatlinks(request: WSGIRequest) -> JsonResponse:
     fatlink_ids = list(
         FatLink.objects.select_related_default()
         .order_by("-created")[:10]
-        .values_list("id", flat=True)
+        .values_list("pk", flat=True)
     )
 
-    fatlinks = FatLink.objects.filter(id__in=fatlink_ids).order_by("-created")
+    fatlinks = FatLink.objects.filter(pk__in=fatlink_ids).order_by("-created")
 
     fatlink_rows = [
         convert_fatlinks_to_dict(

--- a/afat/views/statistics.py
+++ b/afat/views/statistics.py
@@ -147,7 +147,7 @@ def _calculate_year_stats(request, year) -> dict:
     fats_in_year = (
         Fat.objects.filter(fatlink__created__year=year, character__in=characters)
         .values("character__character_id", "fatlink__created__month")
-        .annotate(fat_count=Count("id"))
+        .annotate(fat_count=Count("pk"))
         .order_by("fatlink__created__month", "character__character_name")
     )
 
@@ -359,7 +359,7 @@ def ajax_get_monthly_fats_for_main_character(
             "character__corporation_id",
             "character__corporation_name",
         )
-        .annotate(fat_count=Count("id"))
+        .annotate(fat_count=Count("pk"))
     )
 
     # if main_character.corporation_id != corporation_id:
@@ -465,7 +465,7 @@ def corporation(  # pylint: disable=too-many-statements too-many-branches too-ma
                 fatlink__created__year=year,
             )
             .values("fatlink__created__month")
-            .annotate(fat_count=Count("id"))
+            .annotate(fat_count=Count("pk"))
         )
 
         months = []
@@ -550,13 +550,13 @@ def corporation(  # pylint: disable=too-many-statements too-many-branches too-ma
     characters = EveCharacter.objects.filter(
         character_id__in=character_ids
     ).select_related("character_ownership__user")
-    character_fat_counts = fats.values("character_id").annotate(fat_count=Count("id"))
+    character_fat_counts = fats.values("character_id").annotate(fat_count=Count("pk"))
     character_fat_map = {
         item["character_id"]: item["fat_count"] for item in list(character_fat_counts)
     }
 
     for char in characters:
-        fat_c = character_fat_map.get(char.id, 0)
+        fat_c = character_fat_map.get(char.pk, 0)
         chars[char.character_name] = (fat_c, char.character_id)
         main_character = get_main_character_from_evecharacter(character=char)
 
@@ -651,7 +651,7 @@ def alliance(  # pylint: disable=too-many-statements too-many-branches too-many-
             )
             .order_by("fatlink__created__month")
             .values("fatlink__created__month")
-            .annotate(fat_count=Count("id"))
+            .annotate(fat_count=Count("pk"))
         )
 
         for entry in ally_fats_by_month:


### PR DESCRIPTION
## Description

### Changed

- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
